### PR TITLE
fix: token bucket logic

### DIFF
--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -121,7 +121,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration
+    window: Duration,
   ): Algorithm<RegionContext> {
     const windowDuration = ms(window);
 
@@ -155,11 +155,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
           };
         }
       }
-      const usedTokensAfterUpdate = (await ctx.redis.eval(
-        script,
-        [key],
-        [windowDuration]
-      )) as number;
+      const usedTokensAfterUpdate = (await ctx.redis.eval(script, [key], [windowDuration])) as number;
 
       const success = usedTokensAfterUpdate <= tokens;
       const reset = (bucket + 1) * windowDuration;
@@ -201,7 +197,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration
+    window: Duration,
   ): Algorithm<RegionContext> {
     const script = `
       local currentKey  = KEYS[1]           -- identifier including prefixes
@@ -255,11 +251,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         }
       }
 
-      const remaining = (await ctx.redis.eval(
-        script,
-        [currentKey, previousKey],
-        [tokens, now, windowSize]
-      )) as number;
+      const remaining = (await ctx.redis.eval(script, [currentKey, previousKey], [tokens, now, windowSize])) as number;
 
       const success = remaining >= 0;
       const reset = (currentWindow + 1) * windowSize;
@@ -305,7 +297,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
      * A newly created bucket starts with this many tokens.
      * Useful to allow higher burst limits.
      */
-    maxTokens: number
+    maxTokens: number,
   ): Algorithm<RegionContext> {
     const script = `
         local key         = KEYS[1]           -- identifier including prefixes
@@ -366,7 +358,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
       const [remaining, reset] = (await ctx.redis.eval(
         script,
         [key],
-        [maxTokens, intervalDuration, refillRate, now]
+        [maxTokens, intervalDuration, refillRate, now],
       )) as [number, number];
 
       const success = remaining > 0;
@@ -416,7 +408,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration
+    window: Duration,
   ): Algorithm<RegionContext> {
     const windowDuration = ms(window);
 
@@ -462,11 +454,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         };
       }
 
-      const usedTokensAfterUpdate = (await ctx.redis.eval(
-        script,
-        [key],
-        [windowDuration]
-      )) as number;
+      const usedTokensAfterUpdate = (await ctx.redis.eval(script, [key], [windowDuration])) as number;
       ctx.cache.set(key, usedTokensAfterUpdate);
       const remaining = tokens - usedTokensAfterUpdate;
 

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -121,7 +121,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration,
+    window: Duration
   ): Algorithm<RegionContext> {
     const windowDuration = ms(window);
 
@@ -155,7 +155,11 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
           };
         }
       }
-      const usedTokensAfterUpdate = (await ctx.redis.eval(script, [key], [windowDuration])) as number;
+      const usedTokensAfterUpdate = (await ctx.redis.eval(
+        script,
+        [key],
+        [windowDuration]
+      )) as number;
 
       const success = usedTokensAfterUpdate <= tokens;
       const reset = (bucket + 1) * windowDuration;
@@ -197,7 +201,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration,
+    window: Duration
   ): Algorithm<RegionContext> {
     const script = `
       local currentKey  = KEYS[1]           -- identifier including prefixes
@@ -251,7 +255,11 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         }
       }
 
-      const remaining = (await ctx.redis.eval(script, [currentKey, previousKey], [tokens, now, windowSize])) as number;
+      const remaining = (await ctx.redis.eval(
+        script,
+        [currentKey, previousKey],
+        [tokens, now, windowSize]
+      )) as number;
 
       const success = remaining >= 0;
       const reset = (currentWindow + 1) * windowSize;
@@ -297,7 +305,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
      * A newly created bucket starts with this many tokens.
      * Useful to allow higher burst limits.
      */
-    maxTokens: number,
+    maxTokens: number
   ): Algorithm<RegionContext> {
     const script = `
         local key         = KEYS[1]           -- identifier including prefixes
@@ -339,8 +347,11 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
       
       remaining = tokens - 1
       redis.call("HSET", key, "tokens", remaining)
-      return {remaining, updatedAt + interval}
 
+      local expireAt = math.ceil(((maxTokens - remaining) / refillRate)) * interval
+      redis.call("PEXPIRE", key, expireAt)
+
+      return {remaining, updatedAt + interval}
     
        `;
 
@@ -365,7 +376,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
       const [remaining, reset] = (await ctx.redis.eval(
         script,
         [key],
-        [maxTokens, intervalDuration, refillRate, now],
+        [maxTokens, intervalDuration, refillRate, now]
       )) as [number, number];
 
       const success = remaining > 0;
@@ -415,7 +426,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
     /**
      * The duration in which `tokens` requests are allowed.
      */
-    window: Duration,
+    window: Duration
   ): Algorithm<RegionContext> {
     const windowDuration = ms(window);
 
@@ -461,7 +472,11 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         };
       }
 
-      const usedTokensAfterUpdate = (await ctx.redis.eval(script, [key], [windowDuration])) as number;
+      const usedTokensAfterUpdate = (await ctx.redis.eval(
+        script,
+        [key],
+        [windowDuration]
+      )) as number;
       ctx.cache.set(key, usedTokensAfterUpdate);
       const remaining = tokens - usedTokensAfterUpdate;
 

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -329,7 +329,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
       end
       
       remaining = tokens - 1
-      redis.call("HSET", key, "tokens", remaining)
+      redis.call("HSET", key, "refilledAt", refilledAt, "tokens", remaining)
 
       local expireAt = math.ceil(((maxTokens - remaining) / refillRate)) * interval
       redis.call("PEXPIRE", key, expireAt)

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -327,9 +327,9 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         if now >= updatedAt + interval then
           if tokens <= 0 then 
             -- No more tokens were left before the refill.
-            remaining = math.min(maxTokens, refillRate) - 1
+            remaining = math.min(maxTokens, math.floor((now - updatedAt)/interval) * refillRate) - 1
           else
-            remaining = math.min(maxTokens, tokens + refillRate) - 1
+            remaining = math.min(maxTokens, tokens + math.floor((now - updatedAt)/interval) * refillRate) - 1
           end
         redis.call("HMSET", key, "updatedAt", now, "tokens", remaining)
         return {remaining, now + interval}

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -308,6 +308,9 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         
         local bucket = redis.call("HMGET", key, "refilledAt", "tokens")
         
+        local refilledAt
+        local tokens
+
         if bucket[1] == false then
           refilledAt = now
           tokens = maxTokens

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -305,7 +305,6 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         local interval    = tonumber(ARGV[2]) -- size of the window in milliseconds
         local refillRate  = tonumber(ARGV[3]) -- how many tokens are refilled after each interval
         local now         = tonumber(ARGV[4]) -- current timestamp in milliseconds
-        local remaining   = 0
         
         local bucket = redis.call("HMGET", key, "refilledAt", "tokens")
         
@@ -328,7 +327,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         return {-1, refilledAt + interval}
       end
       
-      remaining = tokens - 1
+      local remaining = tokens - 1
       redis.call("HSET", key, "refilledAt", refilledAt, "tokens", remaining)
 
       local expireAt = math.ceil(((maxTokens - remaining) / refillRate)) * interval

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -329,7 +329,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
             remaining = math.min(maxTokens, numberOfRefills * refillRate) - 1
           else
             remaining = math.min(maxTokens, tokens + numberOfRefills * refillRate) - 1
-          ends
+          end
 
           local lastRefill = updatedAt + numberOfRefills * interval
 


### PR DESCRIPTION
Fixes:
- the expiry logic that was intended to be removed in [this PR](https://github.com/upstash/ratelimit/pull/53) with [this commit](https://github.com/upstash/ratelimit/pull/53/commits/e0b61b1d91a4f1b2ed88f86dc129707d533324e6) was ignored when the code was reformatted ([this commit](https://github.com/upstash/ratelimit/pull/53/commits/ea6e2dea1879b8c575a770c3e3b49304f42d325b)).
- The current implementation doesn't measure the number of intervals that have passed since the last refill. Since we are updating only when a new request is made, some refills might be ignored.