### PR TITLE
Fix sliding window algorithm

### DIFF
--- a/packages/sdk/src/multi.ts
+++ b/packages/sdk/src/multi.ts
@@ -300,7 +300,7 @@ export class MultiRegionRatelimit extends Ratelimit<MultiRegionContext> {
 
       const currentWindow = Math.floor(now / windowSize);
       const currentKey = [identifier, currentWindow].join(":");
-      const previousWindow = currentWindow - windowSize;
+      const previousWindow = currentWindow - 1;
       const previousKey = [identifier, previousWindow].join(":");
 
       const dbs: { redis: Redis; request: Promise<[string[], string[]]> }[] = ctx.redis.map((redis) => ({

--- a/packages/sdk/src/ratelimit.ts
+++ b/packages/sdk/src/ratelimit.ts
@@ -15,7 +15,6 @@ export type RatelimitConfig<TContext> = {
    * Choose one of the predefined ones or implement your own.
    * Available algorithms are exposed via static methods:
    * - Ratelimiter.fixedWindow
-   * - Ratelimiter.slidingLogs
    * - Ratelimiter.slidingWindow
    * - Ratelimiter.tokenBucket
    */


### PR DESCRIPTION
The previous window calculation was wrong. After quantizing the current time into the current window, the previous window is not the one current window - window duration, but simply current window - 1. This miscalculation was causing sliding window to behave like fixed window.

Also, this is a bit subjective but I believe the remaining value we return from the lua script was wrong. In the sliding window, we are not really operating within a fixed window, but an imaginary one that slides as the requests come.

We were simply returning max tokens - number of requests in the current window, but that is possibly more than the number of tokens we would allow, because that was not taking the weighted number of requests from the previous window into account.

If we were %10 into the current window with the number of requests equal to 10,
 and there were 50 requests in the previous window with the max tokens of 100,
we were returning the value 100 - 10 = 90 as the remaining tokens to the user. But, if the user was to make 90 requests at that time, half of them would be rejected, because we are taking the 50 * (1 - 0.1) = 45 requests from the previous window into account while checking if the request should be rejected or not. Therefore, I adjusted the remaining tokens returned from the lua script accordingly.