### PR TITLE
Fix fixed window algorithm

### DIFF
--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -166,7 +166,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
       return {
         success,
         limit: tokens,
-        remaining: tokens - usedTokensAfterUpdate,
+        remaining: Math.max(0, tokens - usedTokensAfterUpdate),
         reset,
         pending: Promise.resolve(),
       };


### PR DESCRIPTION
The value of usedTokensAfterUpdate can be greater than the max number of tokens. To not return a negative remaining value we should take max of it with 0 before returning it.