### PR TITLE
Wrong Ratelimit Console URL

### DIFF
--- a/packages/sdk/src/ratelimit.ts
+++ b/packages/sdk/src/ratelimit.ts
@@ -58,7 +58,7 @@ export type RatelimitConfig<TContext> = {
 
   /**
    * If enabled, the ratelimiter will store analytics data in redis, which you can check out at
-   * https://upstash.com/ratelimit
+   * https://console.upstash.com/ratelimit
    *
    * @default false
    */

--- a/packages/sdk/src/single.ts
+++ b/packages/sdk/src/single.ts
@@ -54,7 +54,7 @@ export type RegionRatelimitConfig = {
 
   /**
    * If enabled, the ratelimiter will store analytics data in redis, which you can check out at
-   * https://upstash.com/ratelimit
+   * https://console.upstash.com/ratelimit
    *
    * @default true
    */


### PR DESCRIPTION
Simples fix for correct the Ratelimit Console URL address.