### PR TITLE
fix: 0 tokens remaining should not be rate limited

### DIFF
--- a/src/single.ts
+++ b/src/single.ts
@@ -369,7 +369,7 @@ export class RegionRatelimit extends Ratelimit<RegionContext> {
         [maxTokens, intervalDuration, refillRate, now],
       )) as [number, number];
 
-      const success = remaining > 0;
+      const success = remaining >= 0;
       if (ctx.cache && !success) {
         ctx.cache.blockUntil(identifier, reset);
       }


### PR DESCRIPTION
[-1 is returned when the number of tokens is currently 0](https://github.com/upstash/ratelimit/blob/3a8cfb00e827188734ac347965cb743a75fcb98a/src/single.ts#L338), and 0 remaining tokens is a valid response and should not be considered a rate limit.