### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   },
   "dependencies": {
     "@upstash/core-analytics": "^0.0.7"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
The license is currently not recognized at npm