### PR TITLE
docs: fix `@default` JSDoc comment for `analytics` config

### DIFF
--- a/src/multi.ts
+++ b/src/multi.ts
@@ -67,7 +67,7 @@ export type MultiRegionRatelimitConfig = {
    * If enabled, the ratelimiter will store analytics data in redis, which you can check out at
    * https://console.upstash.com/ratelimit
    *
-   * @default true
+   * @default false
    */
   analytics?: boolean;
 };

--- a/src/single.ts
+++ b/src/single.ts
@@ -62,7 +62,7 @@ export type RegionRatelimitConfig = {
    * If enabled, the ratelimiter will store analytics data in redis, which you can check out at
    * https://console.upstash.com/ratelimit
    *
-   * @default true
+   * @default false
    */
   analytics?: boolean;
 };


### PR DESCRIPTION
Syncing this with: https://github.com/upstash/ratelimit/blob/3c3818daade86a2fa294cb4785535ecd981d706d/src/ratelimit.ts#L63

Potential follow-up: Maybe the three types `RatelimitConfig`, `RegionRatelimitConfig`, and `MultiRegionRatelimitConfig` should share a base config type that contains the common properties (`prefix`, `ephemeralCache`, `timeout`, and `analytics`).