### PR TITLE
fix sliding window and bucket scripts

### DIFF
--- a/examples/with-vercel-kv/app/page.tsx
+++ b/examples/with-vercel-kv/app/page.tsx
@@ -1,4 +1,4 @@
-import { Ratelimit } from "../../../src";
+import { Ratelimit } from "@upstash/ratelimit";
 import kv from "@vercel/kv";
 import { Inter } from "next/font/google";
 import { headers } from "next/headers";

--- a/src/lua-scripts/single.ts
+++ b/src/lua-scripts/single.ts
@@ -32,7 +32,7 @@ export const slidingWindowScript = `
   end
   local percentageInCurrent = ( now % window ) / window
   -- weighted requests to consider from the previous window
-  requestsInPreviousWindow = math.floor(( incrementBy - percentageInCurrent ) * requestsInPreviousWindow)
+  requestsInPreviousWindow = math.floor(( 1 - percentageInCurrent ) * requestsInPreviousWindow)
   if requestsInPreviousWindow + requestsInCurrentWindow >= tokens then
     return -1
   end
@@ -87,7 +87,7 @@ export const tokenBucketScript = `
 `;
 
 export const cachedFixedWindowScript = `
-  local key     = KEYS[1
+  local key     = KEYS[1]
   local window  = ARGV[1]
   local incrementBy   = ARGV[2] -- increment rate per request at a given value, default is 1
 


### PR DESCRIPTION
`1 - percentageInCurrent` term in the `slidingWindowScript` was changed as `incrementBy - percentageInCurrent` in #79. But it should stay as before. This is because this is used to calculate the "percentage in previous", by subtracting `percentageInCurrent` from 1. Not related to incrementing.

Additionally, adding a missing bracket in the `tokenBucketScript` which was [lost when formatting scripts](https://github.com/upstash/ratelimit/commit/42a7eb1aafdc2d63e81ed03e2bd0423902b9bcb9#diff-0fc51581fe6219129af97f18bd682a7d27656d3939014fe882e8faeede2245d6L89).