### PR TITLE
Fix multi region algorithms

### DIFF
--- a/src/lua-scripts/multi.ts
+++ b/src/lua-scripts/multi.ts
@@ -6,7 +6,7 @@ export const fixedWindowLimitScript = `
 
 	redis.call("HSET", key, id, incrementBy)
 	local fields = redis.call("HGETALL", key)
-	if #fields == 1 and tonumber(fields[1])==incrementBy then
+	if #fields == 2 and tonumber(fields[2])==incrementBy then
 	-- The first time this key is set, and the value will be equal to incrementBy.
 	-- So we only need the expire command once
 	  redis.call("PEXPIRE", key, window)


### PR DESCRIPTION
fixed issues in multi region fixed window:
- ttl not set properly

fixed issues in multi region sliding window:
- remaining was equal to the number of requests allowed per window in the first limit call.
- remaining was not returned as an integer
- synth method didn't calculate allCurrentIds as a set of ids, rather an array of ids which resulted in duplicates
- synth method compared previous in db with current in all dbs. Changed it so that current in db is compared with current in all dbs