### PR TITLE
add information to analytics error

### DIFF
--- a/src/ratelimit.ts
+++ b/src/ratelimit.ts
@@ -182,7 +182,20 @@ export abstract class Ratelimit<TContext extends Context> {
               ...geo,
             })
             .catch((err) => {
-              console.warn("Failed to record analytics", err);
+              let errorMessage = "Failed to record analytics"
+              if (`${err}`.includes("WRONGTYPE")) {
+                errorMessage = `
+Failed to record analytics. See the information below:
+
+This can occur when you uprade to Ratelimit version 1.1.2
+or later from an earlier version.
+
+This occurs simply because the way we store analytics data
+has changed. To avoid getting this error, disable analytics
+for *an hour*, then simply enable it back.\n
+`
+              }
+              console.warn(errorMessage, err);
             });
           res.pending = Promise.all([res.pending, analyticsP]);
         } catch (err) {


### PR DESCRIPTION
updating the error message in rate limit to make the 1.1.2 version transition smoother:

<img width="730" alt="image" src="https://github.com/upstash/ratelimit/assets/57228345/71c8251e-fa9b-412b-90dc-dda0c26697e8">
